### PR TITLE
(feat) Implement internal API testing & minor bugfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+var server = require('./server/server');
+var port = process.env.PORT || 1337;
+
+server.listen(port, function () {
+  console.log('Listening to port %d', port);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Rosie: The shopping list that builds itself.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1", 
+    "start": "node index.js",
+    "test": "node spec/**/*.js"
   },
   "repository": {
     "type": "git",
@@ -21,7 +22,10 @@
     "express": "^4.13.3",
     "gulp": "^3.9.0",
     "q": "^1.4.1",
-    "synaptic": "^1.0.2"
+    "redtape": "^1.0.0",
+    "supertest": "^1.1.0",
+    "synaptic": "^1.0.2",
+    "tape": "^4.2.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",

--- a/server/list-helpers.js
+++ b/server/list-helpers.js
@@ -126,8 +126,10 @@ module.exports = listHelpers = {
     //calculate how long since last bought
     var timeElapsed = listHelpers.timeSincePurchase(itemProps.date);
 
-    //update network with new data
-    appPantry[item].update(item, timeElapsed, 0.1, household);
+    //update network with new data if it is tracked
+    if (itemProps.tracked){
+      appPantry[item].update(item, timeElapsed, 0.1, household);
+    }
 
     //restock in pantry
     itemProps.fullyStocked = true;

--- a/server/routers/buyRouter.js
+++ b/server/routers/buyRouter.js
@@ -8,8 +8,8 @@ var router = express.Router();
  *  Purchase list of items from shopping cart
  */
 router.post('/', function(req, res) {
-  var items = res.body.items;
-  var household = res.body.household;
+  var items = req.body.items;
+  var household = req.body.household;
 
   Q.fcall(listHelpers.buy, items, household)
   .then(function() {

--- a/server/routers/householdRouter.js
+++ b/server/routers/householdRouter.js
@@ -16,7 +16,7 @@ router.get('/', function(req, res) {
  *  Add email to household?
  */
 router.post('/', function(req, res) {
-  res.sendStatus(200);
+  res.sendStatus(201);
 });
 
 /**

--- a/server/server.js
+++ b/server/server.js
@@ -6,7 +6,6 @@ var householdRouter = require('./routers/householdRouter');
 var buyRouter = require('./routers/buyRouter');
 
 var app = express();
-var port = process.env.PORT || 1337;
 
 app.use(bodyParser.json());
 
@@ -30,6 +29,4 @@ app.use('/pantry', pantryRouter);
 app.use('/household', householdRouter);
 app.use('/buy', buyRouter);
 
-app.listen(port, function () {
-  console.log('Listening to port %d', port);
-});
+module.exports = app;

--- a/spec/server/APISpec.js
+++ b/spec/server/APISpec.js
@@ -1,0 +1,146 @@
+var Q = require('q');
+var redtape = require('redtape');
+var request = require('supertest');
+var server = require('../../server/server');
+var listHelpers = require('../../server/list-helpers.js');
+
+var test = redtape({
+  beforeEach: function (cb) {
+    // Add some starting data before each test
+    Q.all([
+      listHelpers.addToPantry('milk', 'household1', 7, 30),
+      listHelpers.addToPantry('rice', 'household1', 6, 20),
+      listHelpers.addToPantry('fruit', 'household1', 7, 23),
+      listHelpers.addToPantry('carrots', 'household1', 7, 15)
+    ])
+    .then(function() {
+      cb();
+    });
+  },
+  afterEach: function (cb) {
+    // Remove the data (will be useful when we are modifying
+    // the neural networks)
+    Q.all([
+      listHelpers.removeFromPantry('milk', 'household1'),
+      listHelpers.removeFromPantry('rice', 'household1'),
+      listHelpers.removeFromPantry('fruit', 'household1'),
+      listHelpers.removeFromPantry('carrots', 'household1')
+    ])
+    .then(function() {
+      cb();
+    });
+  }
+})
+
+test('Server API - /list', function(t) {
+  // request() and its chainable methods
+  // are from Supertest
+  request(server)
+  .get('/list')
+  .expect(200)
+  .expect('Content-Type', /json/)
+  .end(function(err, res) {
+    t.error(err);
+    t.end();
+  });
+
+  request(server)
+  .post('/list')
+  // Untracked item
+  .send({item: 'peanut butter'})
+  .expect(201)
+  .end(function(err, res) {
+    t.error(err);
+    t.end();
+
+    request(server)
+    .delete('/list')
+    .send({item: 'peanut butter'})
+    .expect(200)
+    .end(function(err, res) {
+      t.error(err);
+      t.end();
+    });
+  });
+
+  
+});
+
+
+test('Server API - /pantry', function(t) {
+  request(server)
+  .get('/pantry')
+  .expect(200)
+  //.expect('Content-Type', /json/)
+  .end(function(err, res) {
+    t.error(err);
+    t.end();
+  });
+
+  request(server)
+  .get('/pantry/general')
+  .expect(200)
+  //.expect('Content-Type', /json/)
+  .end(function(err, res) {
+    t.error(err);
+    t.end();
+  });
+
+  request(server)
+  .post('/pantry')
+  .send({item: 'peanut butter'})
+  .expect(201)
+  .end(function(err, res) {
+    t.error(err);
+    t.end();
+  });
+
+  request(server)
+  .delete('/pantry')
+  .send({item: 'peanut butter'})
+  .expect(200)
+  .end(function(err, res) {
+   t.error(err);
+   t.end();
+  });
+});
+
+test('Server API - /household', function(t) {
+  request(server)
+  .get('/household')
+  .expect(200)
+  //.expect('Content-Type', /json/)
+  .end(function(err, res) {
+    t.error(err);
+    t.end();
+  });
+
+  request(server)
+  .post('/household')
+  //.send()
+  .expect(201)
+  .end(function(err, res) {
+    t.error(err);
+    t.end();
+  });
+
+  request(server)
+  .delete('/household')
+  //.send()
+  .expect(200)
+  .end(function(err, res) {
+   t.error(err);
+   t.end();
+  });
+});
+
+test('Server API - /buy', function(t) {
+  request(server)
+  .post('/buy')
+  .send({items: ['milk', 'rice']})
+  .expect(201)
+  .end(function(err, res) {
+    t.error(err);
+    t.end();
+  });
+});


### PR DESCRIPTION
- Refactor express server listener from server.js to index.js (Supertest requires the `app` object from express without it already listening)
- Add `start` and `test` scripts to npm for starting server and running tests respectively
- Add APISpec file for testing internal API
- Fix minor bugs

Connects to #27 
