### PR TITLE
(feat) Add helpers & modify endpts for household

### DIFF
--- a/server/example.js
+++ b/server/example.js
@@ -12,6 +12,7 @@ var removeFromList = listHelpers.removeFromList;
 var buy = listHelpers.buy;
 var removeFromPantry = listHelpers.removeFromPantry;
 var updateExpTime = listHelpers.updateExpTime;
+var householdHelpers = require('./household-helpers.js');
 
 /////////////
 // EXAMPLE //
@@ -22,7 +23,6 @@ db.on('error', function(err) {
 });
 
 var household1 = new Household({});
-
 
 household1.save(function(){
   addToPantry('milk', household1._id);
@@ -138,7 +138,10 @@ setTimeout(function(){
 },5500);
 
 setTimeout(function(){
-  db.close();
+  Household.remove({ _id : household1._id }, function(err) {
+    if (err) console.error(err);
+    db.close();
+  })
 },9000);
 // //if you autoBuild again, nothing in there!
 // autoBuildList('household1');

--- a/server/household-helpers.js
+++ b/server/household-helpers.js
@@ -1,0 +1,28 @@
+var mongoose = require('mongoose');
+var Household = require('./db/householdModel.js');
+
+module.exports = householdHelpers = {
+
+  getHousehold : function() {
+    // Ideally, this will match a user to a household
+    // Right now, we will create one if one doesn't exist
+    // and use only that one
+    return Household.findOne(function(err, household) {
+      if (err) console.error(err);
+      console.log(household);
+      if (!household) {
+        // Create a test household
+        var household = new Household({});
+        household.save(function() {
+          console.log('householdId from helper is ', household._id)
+        })
+      }
+    })
+  },
+
+  removeHousehold : function(householdId) {
+    return Household.remove({ _id: householdId }, function(err) {
+      if (err) console.error(err);
+    })
+  }
+}

--- a/server/routers/householdRouter.js
+++ b/server/routers/householdRouter.js
@@ -1,14 +1,21 @@
 var express = require('express');
 var Q = require('q');
-var listHelpers = require('../list-helpers');
+var householdHelpers = require('../household-helpers');
 var router = express.Router();
 
 /**
  *  GET /household
  *  Returns the household information
+ *  Note: right now, only returning the household id
  */
 router.get('/', function(req, res) {
-  res.sendStatus(200);
+  Q.fcall(householdHelpers.getHousehold)
+  .then(function(household) {
+    res.send({householdId: household[0]._id});
+  })
+  .catch(function() {
+    res.status(404);
+  })
 });
 
 /**

--- a/server/routers/pantryRouter.js
+++ b/server/routers/pantryRouter.js
@@ -8,8 +8,8 @@ var router = express.Router();
  *  Returns the pantry for the household
  *  Includes two lists: tracked and untracked
  */
-router.get('/', function(req, res) {
-  var household = req.body.household;
+router.get('/:id', function(req, res) {
+  var household = req.params.id;
   Q.fcall(listHelpers.getPantry, household)
   .then(function(pantry) {
     res.send(pantry);

--- a/server/server.js
+++ b/server/server.js
@@ -20,13 +20,6 @@ if (process.env.NODE_ENV === 'production') {
   app.use(express.static('client'));
 }
 
-// Adds household to request
-// REMOVE ONCE DB / HOUSEHOLDS / AUTH IMPLEMENTED
-app.use(function(req, res, next) {
-  req.body.household = 'household1';
-  next();
-});
-
 app.use('/list', listRouter);
 app.use('/pantry', pantryRouter);
 app.use('/household', householdRouter);


### PR DESCRIPTION
- Add helpers to household, including getHousehold which will only keep one household at all times (for demoing) and removeHousehold
- Modify `GET` endpoint for `/household`, which will send the ID of the single household in the database (or create it if it is not there, then send back that ID)
- Modify example.js to remove test household at the end
