### PR TITLE
(refactor) Refactor list helpers to use promises

### DIFF
--- a/server/routers/listRouter.js
+++ b/server/routers/listRouter.js
@@ -4,15 +4,15 @@ var listHelpers = require('../list-helpers');
 var router = express.Router();
 
 /**
- *  GET /list
+ *  GET /list/:id
  *  Returns the list generated for the requesting household
  */
-router.get('/', function(req, res) {
-  var household = req.body.household;
+router.get('/:id', function(req, res) {
+  var household = req.params.id;
 
   Q.fcall(listHelpers.autoBuildList, household)
-  .then(function(list) {
-    res.send(list);
+  .then(function(household) {
+    res.send(household[0].list);
   })
   .catch(function(err) {
     res.status(404).send('Cannot retrieve shopping list');

--- a/server/routers/pantryRouter.js
+++ b/server/routers/pantryRouter.js
@@ -4,15 +4,16 @@ var listHelpers = require('../list-helpers');
 var router = express.Router();
 
 /**
- *  GET /pantry
+ *  GET /pantry/household/:id
  *  Returns the pantry for the household
  *  Includes two lists: tracked and untracked
  */
-router.get('/:id', function(req, res) {
+router.get('/household/:id', function(req, res) {
   var household = req.params.id;
+
   Q.fcall(listHelpers.getPantry, household)
-  .then(function(pantry) {
-    res.send(pantry);
+  .then(function(household) {
+    res.send(household[0].pantry);
   })
   .catch(function() {
     res.status(404).send('Cannot retrieve household pantry');


### PR DESCRIPTION
- MongoDB lookups return a promise, so we utilize `.then` methods after each lookup to avoid having to use callbacks
- Modified a part of `addToList` to differentiate the logic if the item is already in the pantry or not
- Fixed bug in `GET` requests to `pantry` and `list` routers where you need to use an appended `id` on the route, and modified the return values for the new promise changes.

Closes #45 
