### PR TITLE
(fix) Fix list and household helper promise returns

### DIFF
--- a/server/household-helpers.js
+++ b/server/household-helpers.js
@@ -1,5 +1,6 @@
 var mongoose = require('mongoose');
 var Household = require('./db/householdModel.js');
+var Q = require('q');
 
 module.exports = householdHelpers = {
 
@@ -7,17 +8,21 @@ module.exports = householdHelpers = {
     // Ideally, this will match a user to a household
     // Right now, we will create one if one doesn't exist
     // and use only that one
-    return Household.findOne(function(err, household) {
-      if (err) console.error(err);
-      console.log(household);
+    return Household.findOne()
+    .then(function(household) {
       if (!household) {
         // Create a test household
-        var household = new Household({});
-        household.save(function() {
-          console.log('householdId from helper is ', household._id)
-        })
+        var newHousehold = new Household({});
+        return newHousehold.save()
+        .then(function(household) {
+          return household._id;
+        });
+      } else {
+        return Q.fcall(function() {
+          return household._id;
+        });
       }
-    })
+    });
   },
 
   removeHousehold : function(householdId) {

--- a/server/routers/buyRouter.js
+++ b/server/routers/buyRouter.js
@@ -11,7 +11,7 @@ router.post('/', function(req, res) {
   var items = req.body.items;
   var household = req.body.household;
 
-  Q.fcall(listHelpers.buy, items, household)
+  listHelpers.buy(items, household)
   .then(function() {
     res.sendStatus(201);
   })

--- a/server/routers/householdRouter.js
+++ b/server/routers/householdRouter.js
@@ -9,13 +9,9 @@ var router = express.Router();
  *  Note: right now, only returning the household id
  */
 router.get('/', function(req, res) {
-  Q.fcall(householdHelpers.getHousehold)
-  .then(function(household) {
-    res.send({householdId: household[0]._id});
-
-    //below: test responses simulating an already existing household and a household that doesn't exist yet.
-    //res.send({householdId: household[0]._id, name: 'King House', members: ['aking123@yahoo.com', 'amk_awesome@hotmail.com', 'paws@thedog.com']});
-    //res.send({});
+  householdHelpers.getHousehold()
+  .then(function(householdId) {
+    res.send({householdId: householdId});
   })
   .catch(function() {
     res.status(404);

--- a/server/routers/listRouter.js
+++ b/server/routers/listRouter.js
@@ -10,9 +10,9 @@ var router = express.Router();
 router.get('/:id', function(req, res) {
   var household = req.params.id;
 
-  Q.fcall(listHelpers.autoBuildList, household)
-  .then(function(household) {
-    res.send(household[0].list);
+  listHelpers.autoBuildList(household)
+  .then(function(list) {
+    res.send(list);
   })
   .catch(function(err) {
     res.status(404).send('Cannot retrieve shopping list');
@@ -27,9 +27,9 @@ router.post('/', function(req, res) {
   var item = req.body.item;
   var household = req.body.household;
 
-  Q.fcall(listHelpers.addToList, item, household)
-  .then(function() {
-    res.sendStatus(201);
+  listHelpers.addToList(item, household)
+  .then(function(list) {
+    res.status(201).send(list);
   })
   .catch(function() {
     res.status(404).send('Cannot add item to shopping list');
@@ -44,9 +44,9 @@ router.delete('/', function(req, res) {
   var item = req.body.item;
   var household = req.body.household;
 
-  Q.fcall(listHelpers.removeFromList, item, household)
-  .then(function() {
-    res.sendStatus(200);
+  listHelpers.removeFromList(item, household)
+  .then(function(list) {
+    res.send(list);
   })
   .catch(function() {
     res.status(404).send('Cannot remove item from shopping list');

--- a/server/routers/pantryRouter.js
+++ b/server/routers/pantryRouter.js
@@ -11,11 +11,11 @@ var router = express.Router();
 router.get('/household/:id', function(req, res) {
   var household = req.params.id;
 
-  Q.fcall(listHelpers.getPantry, household)
-  .then(function(household) {
-    res.send(household[0].pantry);
+  listHelpers.getPantry(household)
+  .then(function(pantry) {
+    res.send(pantry);
   })
-  .catch(function() {
+  .catch(function(err) {
     res.status(404).send('Cannot retrieve household pantry');
   })
 });
@@ -25,7 +25,7 @@ router.get('/household/:id', function(req, res) {
  *  Returns the general pantry (all items)
  */
 router.get('/general', function(req, res) {
-  Q.fcall(listHelpers.getAppPantry)
+  listHelpers.getAppPantry()
   .then(function(appPantry) {
     res.send(appPantry);
   })
@@ -44,9 +44,9 @@ router.post('/', function(req, res) {
   var item = req.body.item;
   var household = req.body.household;
 
-  Q.fcall(listHelpers.addToPantry, item, household)
-  .then(function() {
-    res.sendStatus(201);
+  listHelpers.addToPantry(item, household)
+  .then(function(pantry) {
+    res.status(201).send(pantry);
   })
   .catch(function() {
     res.status(404).send('Cannot add item to pantry');
@@ -62,9 +62,9 @@ router.delete('/', function(req, res) {
   var item = req.body.item;
   var household = req.body.household;
 
-  Q.fcall(listHelpers.removeFromPantry, item, household)
-  .then(function() {
-    res.sendStatus(200);
+  listHelpers.removeFromPantry(item, household)
+  .then(function(pantry) {
+    res.send(pantry);
   })
   .catch(function() {
     res.status(404).send('Cannot add item to pantry');


### PR DESCRIPTION
- Formats all of the DB calls (including `save`) correctly to return promises, which allows us to chain the methods. That way, we can call `.then()` in the router and it will correctly wait for the changes to be saved in the database before sending a response
- Sends back the relevant data for `POST` and `DELETE` requests. @ccfcheng , this way the front-end doesn't have to make another GET request to get the updated shopping / pantry lists

The data being sent back may be in inconsistent formats, but we will tweak as needed.
