### PR TITLE
(refactor) Refactor User invites to store & resolve household refs

### DIFF
--- a/server/db/userModel.js
+++ b/server/db/userModel.js
@@ -5,10 +5,7 @@ var userSchema = new Schema({
   userId: { type: String, required: true, unique: true },
   email: String,
   householdId: String,
-  invites: [{
-    householdName: String,
-    householdId: String
-  }]
+  invites: [Schema.Types.ObjectId] // ObjectId Of households
 });
 
 module.exports = mongoose.model('user', userSchema);

--- a/server/utils.js
+++ b/server/utils.js
@@ -1,0 +1,33 @@
+var Q = require('q');
+
+/**
+* Provides general utility methods
+* @module utils
+* @requires Q
+*/
+/** 
+* Provides general utility methods
+* @class utils
+* @static
+*/
+
+module.exports = {
+  /**
+  * Iterates over an array, mapping the returned value from the iterator
+  * function to an array using promises. This allows us to use .then after
+  * the mapping function completes
+  *
+  * @method promiseMap
+  * @param arr {Array}
+  * The array to iterate over
+  * @param func {Function}
+  * The function to call on each element in the array
+  * @return {Promise}
+  * A promise, which the first argument supplied will be the mapped array
+  */  
+  promiseMap : function(arr, func) {
+    return Q().then(function () {
+      return arr.map(function (el) { return func(el); });
+    }).all();
+  }
+};


### PR DESCRIPTION
- Modify User schema `invites` property to store ObjectId reference for householdId, rather than an unnormalized copy of the Household data
- Refactor `getUser` to resolve the householdId's in `invites` to their respective household objects, then take out some private information before sending back to client
  - Note: anything that returns the User object can run this function to format it correctly, rather than formatting the User each time.
- Create a `utils` module for general functions needed across multiple helper files. @hmfoster , let me know what you think of this

Closes #116 
