### PR TITLE
(feat) Add email integration for inviting existing users to household

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bower_components/
 client/lib
 out/
 public/
+config/
 *.log
 .floo
 .flooignore

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "body-parser": "^1.13.3",
     "express": "^4.13.3",
     "express-jwt": "^3.0.1",
+    "mandrill-api": "^1.0.45",
     "mongoose": "^4.1.4",
     "q": "^1.4.1",
     "redtape": "^1.0.0",

--- a/server/controllers/email.js
+++ b/server/controllers/email.js
@@ -1,0 +1,49 @@
+
+/**
+ * Provides methods for sending emails via Mandrill
+ * @class email
+ * @static
+ */
+var mandrill = require('mandrill-api/mandrill');
+var mandrillAPIKey = process.env.MANDRILL_API_KEY || require('../../config/mandrillConfig').APIKey;
+var mandrill_client = new mandrill.Mandrill(mandrillAPIKey);
+var utils = require('./utils');
+  
+module.exports = {
+  /**
+   *  Sends an invitation email via Mandrill to invitee
+   *  with a link with the inviteId appended to accept invitation
+   *
+   *  @method sendInvitationEmail
+   *  @param {string}     inviteeEmail
+   *  @param {string}     inviteId
+   */
+  sendInvitationEmail : function(inviteeEmail, inviteId) {
+    var link = "http://localhost:1337/user/invite/" + inviteId;
+    var message = {
+      html: "<p>You have been invited to join a household in Rosie!" +
+            "Click on the link below to accept the invitation!</p>" +
+            "<a>" + link + "</a",
+      subject: "Test email",
+      from_email: "kamharrah@gmail.com",
+      from_name: "Rosie",
+      to: [{
+        email: inviteeEmail,
+        type: "to"
+      }],
+      important: false
+    };
+
+    mandrill_client.messages.send({
+        message: message,
+        async: true,
+        ip_pool: "Main Pool",
+        sent_at: "example sent_at"
+      }, function(result) {
+        console.log(result);
+      }, function(err) {
+        console.error(err);
+      });
+  }
+
+};

--- a/server/controllers/utils.js
+++ b/server/controllers/utils.js
@@ -1,4 +1,5 @@
 var Q = require('q');
+var crypto = require('crypto');
 
 /**
 * Provides general utility methods
@@ -29,5 +30,16 @@ module.exports = {
     return Q().then(function () {
       return arr.map(function (el) { return func(el); });
     }).all();
+  },
+
+  /**
+  * Generates a (generally) unique hash
+  *
+  * @method generateHash
+  * @return {String}
+  * A generated hash string
+  */  
+  generateHash : function() {
+    return crypto.randomBytes(10).toString('hex');
   }
 };

--- a/server/db/inviteModel.js
+++ b/server/db/inviteModel.js
@@ -1,0 +1,10 @@
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+
+var inviteSchema = new Schema({
+  inviteId: { type: String, required: true, unique: true },
+  householdId: { type: Schema.Types.ObjectId },
+  inviteeEmail: String
+});
+
+module.exports = mongoose.model('invite', inviteSchema);

--- a/server/routers/userRouter.js
+++ b/server/routers/userRouter.js
@@ -58,6 +58,27 @@ router.post('/', function(req, res) {
 });
 
 /**
+ *  GET /user/invite/:id
+ *  
+ *  Accepts an invitation via email
+ * 
+ *  Finds an invite via ID, then accepts the invitation for that user
+ *
+ *  Redirect to root of app (to load index.html) on success
+ */
+
+router.get('/invite/:id', function(req, res) {
+  var inviteId = req.params.id;
+  userController.updateInvitationViaEmail(inviteId)
+  .then(function() {
+    res.redirect('../../');
+  })
+  .catch(function(err) {
+    res.send(err);
+  });
+});
+
+/**
  *  POST /user/invite
  *  
  *  Creates an invitation for the user
@@ -105,7 +126,6 @@ router.put('/invite', function(req, res) {
     res.sendStatus(404);
   });
 });
-
 
 /**
  *  DELETE /user


### PR DESCRIPTION
- Requires Mandrill-API
  - Note: you will need to create a `config/` folder in the root directory and paste the file I will share with you in that folder
- Setup Mandrill config and add method for sending invitation emails
- Add new `Invite` model for storing InviteId hashes for resolving into the household and invited user
- Modify `createInvitation` to add to the Invite model and send an invitation email with a generated hash
- Add a route handler for handling `GET` requests from emails to accept the invitation, which calls a new method on the User Controller that grabs the necessary params from the Invite model instance.

Connects to #96 
